### PR TITLE
fix: run docker compose instead of docker-compose

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -35,7 +35,7 @@ generate_encrypted_password() {
 run_docker_compose() {
     DOCKER_COMPOSE_ARGS="-f docker-compose.yml up"
     [[ $1 == "prod" ]] && DOCKER_COMPOSE_ARGS+=" -d"
-    docker-compose $DOCKER_COMPOSE_ARGS
+    docker compose $DOCKER_COMPOSE_ARGS
 }
 
 script_entrypoint() {

--- a/stop.sh
+++ b/stop.sh
@@ -5,6 +5,6 @@
 #
 # Uses the admin password specified in the .env file
 DOCKER_COMPOSE_ARGS="-f docker-compose.yml down"
-docker-compose $DOCKER_COMPOSE_ARGS
+docker compose $DOCKER_COMPOSE_ARGS
 
 exit 0


### PR DESCRIPTION
The version without a dash doesn't break docker compose v2